### PR TITLE
f-option

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,7 @@
 // background.js
 
+const downloadIdToFilenameMap = {};
+
 /**
  * アクション定義
  */
@@ -8,10 +10,34 @@ function closeTab(tab, request) {
 }
 
 function saveImage(tab, request) {
-  if (request.targetUrl) {
+  if (!request.targetUrl || !request.pageUrl) {
+    return;
+  }
+
+  const imageUrl = request.targetUrl;
+  const pageUrl = request.pageUrl;
+
+  // https://fantia.jp/posts/{number1}/post_content_photo/{number2} の形式かページURLでチェック
+  const fantiaRegex = /^https:\/\/fantia\.jp\/posts\/(\d+)\/post_content_photo\/(\d+)/;
+  const match = pageUrl.match(fantiaRegex);
+
+  if (match) {
+    const number1 = match[1];
+    const number2 = match[2];
+    const generatedFilename = `${number1}_${number2}.jpg`;
+
+    // ダウンロードを開始し、IDとファイル名のマッピングを保存
+    // saveAs: true を指定して、名前を付けて保存ダイアログを開く
+    chrome.downloads.download({ url: imageUrl, saveAs: true }, (downloadId) => {
+      if (downloadId) {
+        downloadIdToFilenameMap[downloadId] = generatedFilename;
+      }
+    });
+  } else {
+    // それ以外のURLでは自動で保存する
     chrome.downloads.download({
-      url: request.targetUrl,
-      saveAs: true
+      url: imageUrl,
+      saveAs: false // ダイアログを表示せずに自動保存
     });
   }
 }
@@ -20,8 +46,6 @@ function saveImage(tab, request) {
 const gestureActions = {
   'DL': closeTab, // 下、左: タブを閉じる
   'DR': saveImage // 下、右: 画像を保存
-  // 新しいジェスチャーはここに追加
-  // 'U': someAction,
 };
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -31,6 +55,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       action(sender.tab, request);
     }
   }
-  // 非同期でレスポンスを返す場合は true を返す (今回は使わないが作法として)
   return true; 
+});
+
+// ダウンロードのファイル名を決定するリスナー
+chrome.downloads.onDeterminingFilename.addListener((downloadItem, suggest) => {
+  const desiredFilename = downloadIdToFilenameMap[downloadItem.id];
+  if (desiredFilename) {
+    suggest({
+      filename: desiredFilename,
+      conflictAction: 'uniquify' // ファイル名が競合した場合は連番を付ける
+    });
+    // 使用済みのマッピングを削除
+    delete downloadIdToFilenameMap[downloadItem.id];
+  }
+  // このリスナーで非同期処理を行う場合は true ���返す必要がある
+  // 今回は同期的だが、将来的な拡張のために含めておく
+  return true;
 });

--- a/src/background.js
+++ b/src/background.js
@@ -68,8 +68,9 @@ chrome.downloads.onDeterminingFilename.addListener((downloadItem, suggest) => {
     });
     // 使用済みのマッピングを削除
     delete downloadIdToFilenameMap[downloadItem.id];
+    // suggest()を非同期的に呼び出すことを示すためにtrueを返す
+    return true;
   }
-  // このリスナーで非同期処理を行う場合は true ���返す必要がある
-  // 今回は同期的だが、将来的な拡張のために含めておく
-  return true;
+  // desiredFilenameがない場合（elseルート）、デフォルトのファイル名決定プロセスをブロックしないよう、
+  // 何も返さずに（undefinedを返して）リスナーを同期的に完了させます。
 });

--- a/src/content.js
+++ b/src/content.js
@@ -84,7 +84,8 @@ document.addEventListener('mouseup', (event) => {
       chrome.runtime.sendMessage({ 
         action: 'performGesture', 
         gesture: gesture,
-        targetUrl: targetImageUrl 
+        targetUrl: targetImageUrl,
+        pageUrl: window.location.href // 現在のページのURLを追加
       });
     }
     


### PR DESCRIPTION
  ### やったこと

  マウスジェスチャーの画像保存（↓→）機能をパワーアップしました！


  特定のサイト（今はFantiaだけ）で画像を保存するとき、自動でいい感じのファイル名を付けてくれるようになり
  ます。


   - Fantia
       - ページのURLから投稿IDと画像IDを抜き出して、{投稿ID}_{画像ID}.jpgっていうファイル名を自動で付けて
         くれるようにしました。
       - 保存するときは「名前を付けて保存」ダイアログが出るので、保存場所も選べます。
       - Chromeの仕様上、以前の場所を引き継いでくれない．
   - それ以外
       - 今まで通り、画像はサクッと自動でダウンロードされます。

  ### なんでやったか


  Fantiaで画像をたくさん保存するとき、いちいちリネームするのが面倒だったため。

  ### 技術的なこと


   - background.jsでchrome.downloads.onDeterminingFilenameAPIを使い、ダウンロードするファイルの名前を動的
     に変更するようにしました。
   - content.jsから、今見ているページのURLもbackground.jsに教えるようにして、サイトごとに処理を分けられる
     ようにしました。